### PR TITLE
attempt fix for looping web3 warning

### DIFF
--- a/client/src/components/header.js
+++ b/client/src/components/header.js
@@ -1,6 +1,6 @@
 import { navigate } from "gatsby";
 import PropTypes from "prop-types";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState, useMemo } from "react";
 import { Flex, Button, Box } from "rimble-ui";
 import Web3 from "web3";
 import { observer } from "mobx-react-lite";
@@ -20,9 +20,14 @@ const Header = observer(({ siteTitle, menuLinks }) => {
 
   const [timer, setTimer] = useState();
 
+  const windowWeb3 = useMemo(() => {
+    if (window != "undefined") {
+      return new Web3(window.ethereum)
+    }
+  }, [])
+
   const checkWalletAndPendingTransactions = async () => {
-    if (window.ethereum) {
-      let windowWeb3 = new Web3(window.ethereum);
+    if (windowWeb3) {
       const accounts = await windowWeb3.eth.getAccounts();
       walletStore.defaultAddress = accounts[0];
       const isLocked = !accounts || 0 === accounts.length;


### PR DESCRIPTION
This fix is not working for me, getting stuck on a SSR error from mobx: 

![image](https://user-images.githubusercontent.com/16842072/110245793-ef472e80-7f21-11eb-948b-6dae45166645.png)


This solution was working for a minute, but then it stopped and went back to the error, but it definitely seems like window.ethereum should be in the dependencies of the memo so this probably isn't the best solution regardless.

here are a couple related links I found while troubleshooting:
https://github.com/gatsbyjs/gatsby/issues/5835
specifically #1 here: https://www.gatsbyjs.com/docs/debugging-html-builds/#how-to-check-if-code-classlanguage-textwindowcode-is-defined

closes: #24